### PR TITLE
refactor(components): revise github repo link to the correct one

### DIFF
--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -65,7 +65,7 @@ export function Nav() {
               <ThemeSwitcher />
               <Link
                 className={buttonStyles({ appearance: 'outline', size: 'square-petite' })}
-                href="https://github.com/irsyadadl/next-starter-kit"
+                href="https://github.com/justdlabs/remix"
               >
                 <IconBrandGithub />
               </Link>


### PR DESCRIPTION
The current github repo link points to the nextjs version repo. To avoid confusion, this change revise the link to the remix repo.